### PR TITLE
Plugin ScanExtraPorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+#PyCharm
 *.iml
 .idea
 *.pyc
 *~
+#PyDev
+.project
+.pydevproject

--- a/data/path.lst
+++ b/data/path.lst
@@ -63,6 +63,7 @@
 {"url" : "/ftp", "description" : "Ftp directory"}
 {"url" : "/forum", "description" : "Forum directory"}
 {"url" : "/groupware", "description" : "Groupware directory"}
+{"url" : "/gui", "description" : "GUI / uTorrent Web GUI"}
 {"url" : "/img", "description" : "Images directory"}
 {"url" : "/images", "description" : "Images directory"}
 {"url" : "/import", "description" : "Import directory"}
@@ -158,6 +159,9 @@
 {"url" : "/jmx-console", "description" : "JBoss 6 JMX console"}
 {"url" : "/web-console", "description" : "JBoss 6 web console"}
 {"url" : "/console", "description" : "Admin console / JBoss 7 console"}
+
+# Resin
+{"url" : "/resin-admin", "description" : "Resin administration"}
 
 # phpMyAdmin (source: http://downloads.skullsecurity.org/passwords/phpmyadmin-locations.txt)
 {"url" : "/dh_phpmyadmin", "description" : "Dreamhost phpMyAdmin installation"}

--- a/data/path.lst
+++ b/data/path.lst
@@ -46,6 +46,7 @@
 {"url" : "/database", "description" : "Database directory"}
 {"url" : "/document", "description" : "document directory"}
 {"url" : "/documents", "description" : "document directory"}
+{"url" : "/docs", "description" : "document directory"}
 {"url" : "/download", "description" : "file directory"}
 {"url" : "/downloads", "description" : "file directory"}
 {"url" : "/delete", "description" : "Backup Directory"}
@@ -55,12 +56,12 @@
 {"url" : "/db", "description" : "Database directory"}
 {"url" : "/dummy", "description" : "Dummy directory"}
 {"url" : "/_dummy", "description" : "Dummy directory"}
+{"url" : "/examples", "description" : "Examples directory"}
 {"url" : "/files", "description" : "Static files directory"}
 {"url" : "/file", "description" : "Static files directory"}
 {"url" : "/fileadmin", "description" : "Static files administration directory"}
 {"url" : "/ftp", "description" : "Ftp directory"}
 {"url" : "/forum", "description" : "Forum directory"}
-{"url" : "/.git", "description" : "git directory"}
 {"url" : "/groupware", "description" : "Groupware directory"}
 {"url" : "/img", "description" : "Images directory"}
 {"url" : "/images", "description" : "Images directory"}
@@ -83,8 +84,6 @@
 {"url" : "/migrate", "description" : "Database migration directory"}
 {"url" : "/modules", "description" : "Modules directory"}
 {"url" : "/old", "description" : "Old website version"}
-{"url" : "/phpMyAdmin", "description" : "phpMyAdmin installation"}
-{"url" : "/phpmyadmin", "description" : "phpMyAdmin installation"}
 {"url" : "/private", "description" : "Private directory"}
 {"url" : "/protected", "description" : "_Protected_ directory"}
 {"url" : "/pub", "description" : "Public directory"}
@@ -97,7 +96,6 @@
 {"url" : "/settings", "description" : "Settings directory"}
 {"url" : "/sites", "description" : "Subsites directory"}
 {"url" : "/slimstat", "description" : "SlimStats"}
-{"url" : "/sql", "description" : "Sql backups directory"}
 {"url" : "/src", "description" : "Source directory"}
 {"url" : "/.ssh", "description" : "SSH config directory"}
 {"url" : "/safe", "description" : "_Safe_ directory"}
@@ -107,7 +105,6 @@
 {"url" : "/status", "description" : "Stats directory"}
 {"url" : "/statistics", "description" : "Stats directory"}
 {"url" : "/system", "description" : "System directory"}
-{"url" : "/.svn", "description" : "svn directory"}
 {"url" : "/update", "description" : "Update directory"}
 {"url" : "/updates", "description" : "Update directory"}
 {"url" : "/upload", "description" : "Upload directory"}
@@ -147,3 +144,36 @@
 # ActiveCollab
 {"url" : "/activeCollab", "description" : "ActiveCollab"}
 
+# Source control directory
+{"url" : "/CVS", "description" : "CVS directory"}
+{"url" : "/.git", "description" : "Git directory"}
+{"url" : "/.hg", "description" : "Mercurial directory"}
+{"url" : "/.svn", "description" : "SVN directory"}
+
+# Tomcat
+{"url" : "/manager/html", "description" : "Tomcat manager"}
+{"url" : "/host-manager/html", "description" : "Tomcat virtual host manager"}
+
+# JBoss
+{"url" : "/jmx-console", "description" : "JBoss 6 JMX console"}
+{"url" : "/web-console", "description" : "JBoss 6 web console"}
+{"url" : "/console", "description" : "Admin console / JBoss 7 console"}
+
+# phpMyAdmin (source: http://downloads.skullsecurity.org/passwords/phpmyadmin-locations.txt)
+{"url" : "/dh_phpmyadmin", "description" : "Dreamhost phpMyAdmin installation"}
+{"url" : "/myadmin", "description" : "phpMyAdmin installation"}
+{"url" : "/phpMyAdmin", "description" : "phpMyAdmin installation"}
+{"url" : "/phpmyadmin", "description" : "phpMyAdmin installation"}
+{"url" : "/phpmyadmin2", "description" : "phpMyAdmin installation"}
+{"url" : "/phpMyAdmin2", "description" : "phpMyAdmin installation"}
+{"url" : "/PMA", "description" : "phpMyAdmin installation"}
+{"url" : "/pma", "description" : "phpMyAdmin installation"}
+
+# Generic database related directories
+{"url" : "/sql", "description" : "Sql backups directory"}
+{"url" : "/sqlmanager", "description" : "Database web console"}
+{"url" : "/mysqlmanager", "description" : "Database web console"}
+{"url" : "/mysql", "description" : "Database web console"}
+{"url" : "/sqlweb", "description" : "Database web console"}
+{"url" : "/websql", "description" : "Database web console"}
+{"url" : "/webdb", "description" : "Database web console"}

--- a/plugins/host/ScanExtraPorts.py
+++ b/plugins/host/ScanExtraPorts.py
@@ -1,0 +1,172 @@
+from core import conf, database, utils
+import re, httplib, sys
+
+"""
+Plugin : ScanExtraPorts
+Description :
+	Scan for other HTTP services on the same host.
+	If any ports are open, they could serve for future scan with tachyon.
+"""
+
+__author__ =  'h3xStream'
+__version__=  '1.0'
+
+# Ports are structure with tuple (port, description)
+
+COMMON_HTTP_PORTS= [
+	([80],   "Default port"),
+	([81,82,8080,8081,8090], 
+	         "Common alternate port"),
+
+	([591],  "FileMaker"),
+	([593],  "Microsoft Exchange Server RPC"),
+	([4848], "Glassfish admin port"),
+	([8000], "Django default port"),
+	([8008], "IBM HTTP Server"),
+	([3100], "Tatsoft"),
+	([3101], "BlackBerry Enterprise Server"),
+	([3128], "Squid Web caches"),
+	([4567], "Sinatra default port"),
+	([4711], "McAfee Web Gateway 7"),
+	([5104], "IBM Tivoli Framework NetCOOL/Impact"),
+	([5800,5801,5802],
+	         "VNC Web interface"),
+	([7001], "BEA WebLogic Server"),
+	([8280], "Apache Synapse"),
+	([8887], "HyperVM"),
+	([8888], "Common alternate port / GNUmp3d / LoLo Catcher / AppEngine development"),
+	([9080], "WebSphere http"),
+	([9990], "JBoss admin port"),
+	([10041],"WebSphere Portal administration"),
+	
+	([7777], "Oracle HTTP Server"),
+	([7779], "Oracle9iAS Web Cache"),
+	([8007], "Oracle HTTP Server Jserv")
+	]
+
+COMMON_HTTPS_PORTS= [
+	([443],  "Default port"), 
+	
+	([981],  "Check Point FireWall-1 management"),
+	([987],  "Windows SharePoint Services"),
+	([1311], "Dell OpenManage"),
+	([1920], "IBM Tivoli Monitoring Console"),
+	([4712], "McAfee Web Gateway 7"),
+	([7000], "Vuze Bittorrent tracker"),
+	([7002], "BEA WebLogic Server"),
+	([8243], "Apache Synapse"),
+	([8888], "HyperVM"),
+	
+	([4443], "Oracle HTTP Server"),
+	([4444], "Oracle9iAS Web Cache")
+	]
+
+#Web related but not HTTP
+COMMON_TCP_PORTS = [
+	([8172],      "IIS Web Management Service")
+	]
+
+# Sources for common ports
+# 1. http://www.red-database-security.com/whitepaper/oracle_default_ports.html
+# 2. http://publib.boulder.ibm.com/infocenter/wasinfo/v6r0/index.jsp?topic=%2Fcom.ibm.websphere.express.doc%2Finfo%2Fexp%2Fae%2Frins_portnumber.html
+# 3. http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+
+LOG_PREFIX = " - ScanExtraPorts Plugin: "
+	
+def logInfo(message,prefix=LOG_PREFIX):
+	utils.output_info("%s%s" % (prefix,message))
+
+def logDebug(message,prefix=LOG_PREFIX):
+	utils.output_debug("%s%s" % (prefix,message))
+
+def logRewrite(message):
+	sys.stdout.write("\r%s" % (message))
+
+def clearLine():
+	sys.stdout.write("\r");
+
+
+def genericScan(listPortsInfos,host,skipPort=80,visitor= lambda host,port: (),results=[],label=""):
+	"""Generic Scan loop that take a visitor to do the actual connection.
+	
+	Arguments:
+	listPortsInfos -- List of ports info (COMMON_HTTP_PORTS, COMMON_HTTPS_PORTS)
+	host -- Remote host
+	skipPort -- The plugin will not probe the port of the current scan for files.
+	visitor -- Function that will try to connect to a port and throw an exception if it failed.
+	httpResults -- Results are append to this list
+	"""
+	i=0
+	total=len(listPortsInfos)
+	
+	for portGroupInfo in listPortsInfos :
+		i+=1
+		
+		for scanPort in portGroupInfo[0]:
+			
+			if scanPort == skipPort:
+				continue #Avoid suggesting the port initially specified
+			
+			#Testing if the the port is open and is a HTTP service.
+			portOpen = False
+			
+			logRewrite("(%i/%i) Scanning %s port %i " % (i,total,label,scanPort))
+			
+			try:
+				visitor(host,scanPort)
+				
+				portOpen = True
+			except:
+				pass
+			
+			if portOpen :
+				results.append((scanPort,portGroupInfo[1],label))
+	
+	clearLine(); #Clear the loading info (Scanning..)
+
+def execute():
+	logInfo("Starting a quick port scan")
+	
+	re_host = re.search('(https://|http://)([^/:]+)(:([0-9]+))?',conf.target_host)
+	
+	currentHost = re_host.group(2)
+	
+	#Extract port otherwise default port
+	currentPort = int(re_host.group(4)) if re_host.group(4) else 80 \
+		if conf.target_host.startswith('http://') else 443
+	
+	#print "host=%s port=%i" % (currentHost, currentPort)
+	
+	globalResults = []
+	
+	
+	#Scanning for HTTP services
+	
+	def httpScan(host,port):
+		
+		conn = httplib.HTTPConnection(host,port,timeout=2)
+		conn.request("GET", "/"); #Response is ignore
+		conn.close()
+	
+	genericScan(COMMON_HTTP_PORTS,currentHost,currentPort,httpScan,globalResults,"HTTP")
+	
+	#Scanning for HTTPS services
+	
+	def httpsScan(host,port):
+		conn = httplib.HTTPSConnection(host,port,timeout=2)
+		conn.request("GET", "/"); #Response is ignore
+		conn.close()
+	
+	genericScan(COMMON_HTTPS_PORTS,currentHost,currentPort,httpsScan,globalResults,"HTTPS")
+	
+	#Printing final result
+	
+	logInfo("%i extra port(s) open" % (len(globalResults)));
+	
+	for res in globalResults:
+		logInfo("Port %i is open. | %s (%s)" % res,"")
+
+
+if __name__ == "__main__":
+	conf.target_host = 'http://localhost/'
+	execute()

--- a/plugins/host/__init__.py
+++ b/plugins/host/__init__.py
@@ -17,5 +17,5 @@
 #
 
 # Add all host plugins here
-__all__ = ["Robots", "PathGenerator", "HostProcessor"]
+__all__ = ["Robots", "PathGenerator", "HostProcessor", "ScanExtraPorts"]
   


### PR DESCRIPTION
Petit plugin qui _suggère_ de scanner certains ports ouverts autres que celui spécifié dans le scan courant.
Permet de découvrir d'autre services HTTP se trouvant sur le même host (comme des pages d'administration connexes).

J'ai aussi ajouté quelques dossiers au passage.
