### PR TITLE
Clearing request headers on each url fetch

### DIFF
--- a/core/fetcher.py
+++ b/core/fetcher.py
@@ -19,7 +19,10 @@ from core import database
 from core import conf
 
 class Fetcher(object):
-    def fetch_url(self, url, user_agent, timeout, limit_len=True, add_headers=dict()):
+    def fetch_url(self, url, user_agent, timeout, limit_len=True):
+
+        add_headers = dict()
+
         """ Fetch a given url, with a given user_agent and timeout"""
         try:
             if not add_headers.get('User-Agent'):


### PR DESCRIPTION
This pull request address an initialization problem with the add_headers dictionary. The add_headers is a mutable variables and is not cleared on each call which leaves unwanted headers from previous calls still active.

http://effbot.org/zone/default-values.htm

How to reproduce:
1. call fetch_url with limit_len = true.
2. "Range" key is added.
3. call fetch_url with limit_len = false.
4. "Range" key should be removed but it is still defined from the previous call.

This leftover "Range" header modified the response code of some request on my test target which broke the Robots plugin and the SVN plugin as it was receiving a 206 http response code instead of a 200.
