### PR TITLE
Use /usr/bin/env to discover system python executable

### DIFF
--- a/tachyon.py
+++ b/tachyon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Tachyon - Fast Multi-Threaded Web Discovery Tool
 # Copyright (c) 2011 Gabriel Tremblay - initnull hat gmail.com


### PR DESCRIPTION
For people whos /usr/bin/python is not their main python installation... (osx brew python)
