### PR TITLE
Revalidate results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-hammertime-http>=0.4.6
+hammertime-http>=0.5.0
 easyinject==0.3
 click==6.7

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         ]
     },
     install_requires=[
-        'hammertime-http>=0.4.6,<0.5',
+        'hammertime-http>=0.5.0,<0.6',
         'easyinject==0.3',
         'click>=6.7,<7'
     ],

--- a/tachyon/__init__.py
+++ b/tachyon/__init__.py
@@ -15,3 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
+
+from .__version__ import __version__
+
+__all__ = ["__version__"]

--- a/tachyon/__main__.py
+++ b/tachyon/__main__.py
@@ -129,7 +129,7 @@ async def scan(hammertime, *, accumulator,
 
     await load_execute_host_plugins(hammertime)
 
-    async for _ in hammertime.successful_requests():
+    async for _ in hammertime.successful_requests():  # noqa: F841
         pass  # Just drain the pre-probe queries from the queue
 
     if not plugins_only:

--- a/tachyon/__main__.py
+++ b/tachyon/__main__.py
@@ -26,12 +26,11 @@ import tachyon.loaders as loaders
 import tachyon.textutils as textutils
 from hammertime.rules import RejectStatusCode
 from hammertime.rules.deadhostdetection import OfflineHostException
-from hammertime.ruleset import RejectRequest
+from hammertime.ruleset import RejectRequest, StopRequest
 from tachyon.directoryfetcher import DirectoryFetcher
 from tachyon.filefetcher import FileFetcher
 
 import tachyon.conf as conf
-from tachyon.__version__ import __version__
 from tachyon.config import configure_hammertime, set_cookies, default_user_agent, custom_event_loop
 from tachyon.generator import PathGenerator, FileGenerator
 from tachyon.plugins import host, file
@@ -112,12 +111,6 @@ async def test_file_exists(hammertime, accumulator):
         await fetcher.fetch_files(database.valid_paths)
 
 
-def print_program_header():
-    """ Print a _cute_ program header """
-    header = "\n\t Tachyon v%s - Fast Multi-Threaded Web Discovery Tool\n\t https://github.com/delvelabs/tachyon\n"
-    click.echo(header % __version__)
-
-
 def format_stats(stats):
     message = "Statistics: Requested: {}; Completed: {}; Duration: {:.0f} s; Retries: {}; Request rate: {:.2f}"
     return message.format(stats.requested, stats.completed, stats.duration, stats.retries, stats.rate)
@@ -161,16 +154,22 @@ async def scan(hammertime, *, accumulator,
 def main(*, target_host, cookie_file, json_output, max_retry_count, plugin_settings, proxy, user_agent, vhost,
          depth_limit, directories_only, files_only, plugins_only, recursive, allow_download, confirmation_factor):
 
-    if not json_output:
-        print_program_header()
+    output_manager = textutils.init_log(json_output)
+    output_manager.output_header()
 
     # Ensure the host is of the right format and set it in config
     parsed_url = urlparse(target_host)
+    if not parsed_url.scheme:
+        parsed_url = urlparse("http://%s" % target_host)
+
+    if not parsed_url:
+        output_manager.output_error("Invald URL provided.")
+        return
+
     # Set conf values
     conf.target_host = parsed_url.netloc
     conf.base_url = "%s://%s" % (parsed_url.scheme, parsed_url.netloc)
 
-    output_manager = textutils.init_log(json_output)
     accumulator = ResultAccumulator(output_manager=output_manager)
 
     output_manager.output_info('Starting Discovery on ' + conf.base_url)
@@ -204,7 +203,7 @@ def main(*, target_host, cookie_file, json_output, max_retry_count, plugin_setti
 
     except (KeyboardInterrupt, asyncio.CancelledError):
         output_manager.output_error('Keyboard Interrupt Received')
-    except OfflineHostException:
+    except (OfflineHostException, StopRequest):
         output_manager.output_error("Target host seems to be offline.")
     finally:
         textutils.output_info(format_stats(hammertime.stats))

--- a/tachyon/__main__.py
+++ b/tachyon/__main__.py
@@ -152,9 +152,10 @@ async def scan(hammertime, *, cookies=None, directories_only=False, files_only=F
 @click.option("-r", "--recursive", is_flag=True)
 @click.option("-u", "--user-agent", default=default_user_agent)
 @click.option("-v", "--vhost", type=str, default=None)
+@click.option("-C", "--confirmation-factor", default=1)
 @click.argument("target_host")
 def main(*, target_host, cookie_file, json_output, max_retry_count, plugin_settings, proxy, user_agent, vhost,
-         depth_limit, directories_only, files_only, plugins_only, recursive, allow_download):
+         depth_limit, directories_only, files_only, plugins_only, recursive, allow_download, confirmation_factor):
 
     if not json_output:
         print_program_header()
@@ -186,7 +187,8 @@ def main(*, target_host, cookie_file, json_output, max_retry_count, plugin_setti
         loop = custom_event_loop()
         hammertime = loop.run_until_complete(
             configure_hammertime(cookies=conf.cookies, proxy=conf.proxy_url, retry_count=max_retry_count,
-                                 user_agent=conf.user_agent, vhost=conf.forge_vhost))
+                                 user_agent=conf.user_agent, vhost=conf.forge_vhost,
+                                 confirmation_factor=confirmation_factor))
         loop.run_until_complete(scan(hammertime, cookies=conf.cookies, directories_only=directories_only,
                                      files_only=files_only, plugins_only=plugins_only, depth_limit=depth_limit,
                                      recursive=recursive))

--- a/tachyon/config.py
+++ b/tachyon/config.py
@@ -50,11 +50,11 @@ async def configure_hammertime(proxy=None, retry_count=3, cookies=None, **kwargs
     return hammertime
 
 
-def setup_hammertime_heuristics(hammertime, *, user_agent=default_user_agent, vhost=None):
+def setup_hammertime_heuristics(hammertime, *, user_agent=default_user_agent, vhost=None, confirmation_factor=1):
     #  TODO Make sure rejecting 404 does not conflict with tomcat fake 404 detection.
     global heuristics_with_child
     dead_host_detection = DeadHostDetection(threshold=200)
-    detect_soft_404 = DetectSoft404(distance_threshold=6)
+    detect_soft_404 = DetectSoft404(distance_threshold=6, confirmation_factor=confirmation_factor)
     follow_redirects = FollowRedirects()
     heuristics_with_child = [RejectCatchAllRedirect(), follow_redirects,
                              RejectIgnoredQuery()]

--- a/tachyon/config.py
+++ b/tachyon/config.py
@@ -22,13 +22,14 @@ from aiohttp.cookiejar import DummyCookieJar
 from hammertime import HammerTime
 from hammertime.config import custom_event_loop
 from hammertime.engine import AioHttpEngine
+from hammertime.kb import KnowledgeBase
 from hammertime.ruleset import StopRequest
 from hammertime.rules import DetectSoft404, RejectStatusCode, DynamicTimeout, RejectCatchAllRedirect, FollowRedirects, \
-    SetHeader, DeadHostDetection, FilterRequestFromURL, DetectBehaviorChange, IgnoreLargeBody, \
-    RejectSoft404
+    SetHeader, DeadHostDetection, FilterRequestFromURL, DetectBehaviorChange, IgnoreLargeBody
 
 from tachyon import conf
 from tachyon.heuristics import RejectIgnoredQuery, LogBehaviorChange, MatchString, RedirectLimiter, StripTag
+from tachyon.filefetcher import ValidateEntry
 
 heuristics_with_child = []
 initial_limit = 5120
@@ -45,8 +46,11 @@ async def configure_hammertime(proxy=None, retry_count=3, cookies=None, **kwargs
         engine.session = ClientSession(loop=loop, connector=connector, cookie_jar=DummyCookieJar(loop=loop))
     else:
         engine.session = ClientSession(loop=loop, connector=connector)
-    hammertime = HammerTime(loop=loop, request_engine=engine, retry_count=retry_count, proxy=proxy)
+    kb = KnowledgeBase()
+    hammertime = HammerTime(loop=loop, request_engine=engine, retry_count=retry_count, proxy=proxy, kb=kb)
     setup_hammertime_heuristics(hammertime, **kwargs)
+    hammertime.collect_successful_requests()
+    hammertime.kb = kb
     return hammertime
 
 
@@ -80,9 +84,10 @@ def setup_hammertime_heuristics(hammertime, *, user_agent=default_user_agent, vh
     hammertime.heuristics.add_multiple(heuristics_with_child)
     hammertime.heuristics.add_multiple([
         detect_soft_404,
-        RejectSoft404(),
         MatchString(),
+        ValidateEntry(),
         DetectBehaviorChange(buffer_size=100),
+        ValidateEntry(),
         LogBehaviorChange(),
     ])
     detect_soft_404.child_heuristics.add_multiple(init_heuristics)

--- a/tachyon/config.py
+++ b/tachyon/config.py
@@ -87,8 +87,8 @@ def setup_hammertime_heuristics(hammertime, *, user_agent=default_user_agent, vh
         MatchString(),
         ValidateEntry(),
         DetectBehaviorChange(buffer_size=100),
-        ValidateEntry(),
         LogBehaviorChange(),
+        ValidateEntry(),
     ])
     detect_soft_404.child_heuristics.add_multiple(init_heuristics)
     detect_soft_404.child_heuristics.add_multiple(heuristics_with_child)

--- a/tachyon/directoryfetcher.py
+++ b/tachyon/directoryfetcher.py
@@ -23,15 +23,17 @@ from urllib.parse import urljoin
 from hammertime.rules.deadhostdetection import OfflineHostException
 from hammertime.ruleset import RejectRequest, StopRequest
 
-from tachyon import textutils
+from .textutils import output_manager, PrettyOutput
+from .result import ResultAccumulator
 from tachyon import database
 
 
 class DirectoryFetcher:
 
-    def __init__(self, target_host, hammertime):
+    def __init__(self, target_host, hammertime, accumulator=None):
         self.target_host = target_host
         self.hammertime = hammertime
+        self.accumulator = accumulator or ResultAccumulator(output_manager=output_manager or PrettyOutput())
 
     async def fetch_paths(self, paths):
         requests = []
@@ -49,38 +51,10 @@ class DirectoryFetcher:
                 if entry.response.code != 401:
                     database.valid_paths.append(entry.arguments["path"])
                 if entry.arguments["path"]["url"] != "/":
-                    self.output_found(entry)
+                    self.accumulator.add_entry(entry)
             except OfflineHostException:
                 raise
             except RejectRequest:
                 pass
             except StopRequest:
                 continue
-
-    def output_found(self, entry):
-        if entry.response.code == 401:
-            self._format_output(entry, "Password Protected - ")
-        elif entry.response.code == 403:
-            self._format_output(entry, "*Forbidden* ")
-        elif entry.response.code == 404 and self.detect_tomcat_fake_404(entry.response.raw):
-            self._format_output(entry, "Tomcat redirect, ", special="tomcat-redirect")
-        elif entry.response.code == 500:
-            self._format_output(entry, "ISE, ")
-        else:
-            self._format_output(entry)
-
-    def _format_output(self, entry, desc_prefix="", **kwargs):
-        path = entry.arguments["path"]
-        url = entry.request.url
-        desc = path["description"]
-        data = {"description": desc, "url": url, "code": entry.response.code,
-                "severity": path.get('severity', "warning")}
-        data.update(**kwargs)
-        textutils.output_found("{0}{1} at: {2}".format(desc_prefix, desc, url), data)
-
-    def detect_tomcat_fake_404(self, content):
-        """ An apache setup will issue a 404 on an existing path if there is a tomcat trying to handle jsp on the same
-            host """
-        if content.find(b'Apache Tomcat/') != -1:
-            return True
-        return False

--- a/tachyon/filefetcher.py
+++ b/tachyon/filefetcher.py
@@ -32,7 +32,7 @@ class FileFetcher:
     def __init__(self, host, hammertime, accumulator=None):
         self.host = host
         self.hammertime = hammertime
-        self.accumulator = accumulator or ResultAccumulator(output_manager=output_manager or PrettyOutput)
+        self.accumulator = accumulator or ResultAccumulator(output_manager=output_manager or PrettyOutput())
 
     async def fetch_files(self, file_list):
         requests = []

--- a/tachyon/generator.py
+++ b/tachyon/generator.py
@@ -74,11 +74,20 @@ class FileGenerator:
                               '.sql.bak', '0', '1', '2', '.xml', '.csv', '.wsdl', '.pwd', '.yml']
         self.executables_suffixes = ['.php', '.asp', '.aspx', '.pl', '.cgi', '.cfm']
 
-    def generate_files(self):
+    def generate_files(self, skip_root=False):
         files = list()
         for path in database.valid_paths:
-            files.extend(self._add_all_possible_files_to_path(path))
+            if not skip_root or not self._is_root(path):
+                files.extend(self._add_all_possible_files_to_path(path))
         return files
+
+    def _is_root(self, path):
+        if path == "/":
+            return True
+        elif isinstance(path, dict):
+            return self._is_root(path["url"])
+        else:
+            return False
 
     def _add_all_possible_files_to_path(self, path):
         for file in database.files:

--- a/tachyon/heuristics/logbehaviorchange.py
+++ b/tachyon/heuristics/logbehaviorchange.py
@@ -22,19 +22,13 @@ from tachyon.textutils import output_info
 
 class LogBehaviorChange:
 
+    MESSAGE = "Behavior change detected! The above results are known to be unreliable. " \
+              "Re-validation will occur at the end of the scan."
+
     def __init__(self):
-        self.is_behavior_normal = True
+        self.has_error = False
 
     async def after_response(self, entry):
-        if self._has_behavior_changed(entry):
-            if self._is_normal_behavior_restored(entry):
-                output_info("Normal behavior seems to be restored.")
-            else:
-                output_info("Behavior change detected! Results may be incomplete or tachyon may never exit.")
-        self.is_behavior_normal = not entry.result.error_behavior
-
-    def _has_behavior_changed(self, entry):
-        return self.is_behavior_normal == entry.result.error_behavior
-
-    def _is_normal_behavior_restored(self, entry):
-        return not self.is_behavior_normal and not entry.result.error_behavior
+        if not self.has_error and entry.result.error_behavior:
+            self.has_error = True
+            output_info(self.MESSAGE)

--- a/tachyon/heuristics/matchstring.py
+++ b/tachyon/heuristics/matchstring.py
@@ -22,6 +22,9 @@ import binascii
 
 class MatchString:
 
+    async def before_request(self, entry):
+        entry.result.string_match = False
+
     async def after_response(self, entry):
         if "file" in entry.arguments:
             if "match_string" in entry.arguments["file"]:

--- a/tachyon/output.py
+++ b/tachyon/output.py
@@ -85,12 +85,8 @@ class JSONOutput(OutputManager):
 
 class PrettyOutput(OutputManager):
 
-    def __init__(self):
-        self.result_buffer = []
-
     def flush(self):
-        for result in self.result_buffer:
-            self.output_raw_message(result)
+        pass
 
     def output_header(self):
         """ Print a _cute_ program header """
@@ -99,10 +95,7 @@ class PrettyOutput(OutputManager):
 
     def _add_output(self, text, level, data=None):
         formatted = self._format_output(self._get_current_time(), logging.getLevelName(level), text, data)
-        if level == FOUND:
-            self.result_buffer.append(formatted)
-        else:
-            self.output_raw_message(formatted)
+        self.output_raw_message(formatted)
 
     def _format_output(self, time, level_name, text, data):
         output_format = "[{time}] [{level}] {text}"

--- a/tachyon/output.py
+++ b/tachyon/output.py
@@ -48,6 +48,9 @@ class OutputManager:
     def output_raw_message(self, message):
         click.echo(message)
 
+    def output_header(self):
+        pass
+
     def flush(self):
         raise NotImplementedError
 
@@ -88,6 +91,11 @@ class PrettyOutput(OutputManager):
     def flush(self):
         for result in self.result_buffer:
             self.output_raw_message(result)
+
+    def output_header(self):
+        """ Print a _cute_ program header """
+        header = "\n\t Tachyon v%s - Fast Multi-Threaded Web Discovery Tool\n\t https://github.com/delvelabs/tachyon\n"
+        self.output_raw_message(header % __version__)
 
     def _add_output(self, text, level, data=None):
         formatted = self._format_output(self._get_current_time(), logging.getLevelName(level), text, data)

--- a/tachyon/result.py
+++ b/tachyon/result.py
@@ -1,0 +1,62 @@
+from hammertime.rules.redirects import valid_redirects
+
+
+class ResultAccumulator:
+
+    def __init__(self, *, output_manager):
+        self.output_manager = output_manager
+
+    def add_entry(self, entry):
+        self.output_found(entry)
+
+    def output_found(self, entry, **kwargs):
+        message = self._format_message(entry)
+        data = self._get_data(entry, kwargs)
+        self.output_manager.output_result(message, data=data)
+
+    def _format_message(self, entry):
+        url = entry.request.url
+        data = entry.arguments.get("file") or entry.arguments.get("path")
+        message_prefix = self._get_prefix(entry)
+        return "{prefix}{desc} at: {url}".format(prefix=message_prefix, desc=data["description"], url=url)
+
+    def _get_prefix(self, entry):
+        if "file" in entry.arguments:
+            if entry.response.code == 500:
+                return "ISE, "
+            elif len(entry.response.raw) == 0:
+                return "Empty "
+        if "path" in entry.arguments:
+            if entry.response.code == 401:
+                return "Password Protected - "
+            elif entry.response.code == 403:
+                return "*Forbidden* "
+            elif entry.response.code == 404 and self._detect_tomcat_fake_404(entry.response.raw):
+                return "Tomcat redirect, "
+            elif entry.response.code == 500:
+                return "ISE, "
+
+        return ""
+
+    def _get_data(self, entry, additional):
+        url = entry.request.url
+        descriptor = entry.arguments.get("file") or entry.arguments.get("path")
+
+        data = {"url": url,
+                "description": descriptor["description"],
+                "code": entry.response.code,
+                "severity": descriptor.get('severity', "warning")}
+        data.update(additional)
+
+        if self._detect_tomcat_fake_404(entry.response.raw):
+            data["special"] = "tomcat-redirect"
+
+        return data
+
+    def _detect_tomcat_fake_404(self, content):
+        """ An apache setup will issue a 404 on an existing path if there is a tomcat trying to handle jsp on the same
+            host """
+        if content.find(b'Apache Tomcat/') != -1:
+            return True
+
+        return False

--- a/tachyon/result.py
+++ b/tachyon/result.py
@@ -17,9 +17,10 @@ class ResultAccumulator:
                 self._output_found(entry, confirmed=True)
 
     def _output_found(self, entry, **kwargs):
-        data = self._get_data(entry, kwargs)
-        message = self._format_message(entry, data)
-        self.output_manager.output_result(message, data=data)
+        if "file" in entry.arguments or "path" in entry.arguments:
+            data = self._get_data(entry, kwargs)
+            message = self._format_message(entry, data)
+            self.output_manager.output_result(message, data=data)
 
     def _format_message(self, entry, data):
         url = entry.request.url

--- a/tachyon/result.py
+++ b/tachyon/result.py
@@ -1,4 +1,3 @@
-from hammertime.rules.redirects import valid_redirects
 
 
 class ResultAccumulator:
@@ -15,7 +14,7 @@ class ResultAccumulator:
         self.output_manager.output_result(message, data=data)
 
     def _format_message(self, entry):
-        url = entry.request.url
+        url = self._find_url(entry)
         data = entry.arguments.get("file") or entry.arguments.get("path")
         message_prefix = self._get_prefix(entry)
         return "{prefix}{desc} at: {url}".format(prefix=message_prefix, desc=data["description"], url=url)
@@ -39,7 +38,7 @@ class ResultAccumulator:
         return ""
 
     def _get_data(self, entry, additional):
-        url = entry.request.url
+        url = self._find_url(entry)
         descriptor = entry.arguments.get("file") or entry.arguments.get("path")
 
         data = {"url": url,
@@ -60,3 +59,8 @@ class ResultAccumulator:
             return True
 
         return False
+
+    def _find_url(self, entry):
+        if entry.result.redirects:
+            return self._find_url(entry.result.redirects[-1])
+        return entry.request.url

--- a/tachyon/textutils.py
+++ b/tachyon/textutils.py
@@ -49,3 +49,5 @@ def init_log(json_output):
         output_manager = JSONOutput()
     else:
         output_manager = PrettyOutput()
+
+    return output_manager

--- a/test/directoryfetcher_test.py
+++ b/test/directoryfetcher_test.py
@@ -38,6 +38,7 @@ class TestDirectoryFetcher(TestCase):
 
     def async_setup(self, loop):
         self.hammertime = HammerTime(loop=loop, request_engine=FakeHammerTimeEngine())
+        self.hammertime.collect_successful_requests()
         self.hammertime.heuristics.add_multiple([SetFlagInResult("soft404", False),
                                                  SetFlagInResult("error_behavior", False)])
         self.directory_fetcher = DirectoryFetcher(self.host, self.hammertime)
@@ -143,24 +144,6 @@ class TestDirectoryFetcher(TestCase):
         await self.directory_fetcher.fetch_paths(create_json_data(paths))
         requested = list(self.hammertime.request_engine.request_engine.get_requested_urls())[0]
         self.assertEqual(requested, self.host + "/")
-
-    @async()
-    async def test_fetch_paths_ignore_soft404(self, output_result, loop):
-        self.async_setup(loop)
-        self.hammertime.heuristics.add(SetFlagInResult("soft404", True))
-
-        await self.directory_fetcher.fetch_paths(create_json_data(["path"]))
-
-        output_result.assert_not_called()
-
-    @async()
-    async def test_fetch_paths_ignore_behavior_error(self, output_result, loop):
-        self.async_setup(loop)
-        self.hammertime.heuristics.add(SetFlagInResult("error_behavior", True))
-
-        await self.directory_fetcher.fetch_paths(create_json_data(["path"]))
-
-        output_result.assert_not_called()
 
     def expected_output(self, path, *, code=200, message_prefix=""):
         url = "{}{}/".format(self.host, path["url"])

--- a/test/filefetcher_test.py
+++ b/test/filefetcher_test.py
@@ -31,7 +31,7 @@ from tachyon.config import setup_hammertime_heuristics
 from tachyon.filefetcher import FileFetcher
 
 
-@patch("tachyon.filefetcher.output_found")
+@patch("tachyon.output.OutputManager.output_result")
 class TestFileFetcher(TestCase):
 
     def setUp(self):

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -147,5 +147,8 @@ class SetFlagInResult:
         self.value = value
         self.child_heuristics = MagicMock()
 
+    async def before_request(self, entry):
+        setattr(entry.result, self.flag, self.value)
+
     async def after_response(self, entry):
         setattr(entry.result, self.flag, self.value)

--- a/test/output_test.py
+++ b/test/output_test.py
@@ -88,16 +88,6 @@ class TestPrettyOutput(TestCase):
     def setUp(self):
         self.output = PrettyOutput()
 
-    def test_output_result_add_found_to_result_buffer(self):
-        url = "http://example.com/y"
-        result = "File x found at " + url
-        data = {"url": url, "severity": "critical", "description": "File x desc", "code": 200}
-        output = PrettyOutput()
-
-        output.output_result(result, data=data)
-
-        self.assertEqual(output.result_buffer, ["[12:00:00] [FOUND] %s" % result])
-
     @patch("tachyon.output.click")
     def test_output_info_print_message_with_level_info(self, click):
         message = "information..."

--- a/test/result_accumulator_test.py
+++ b/test/result_accumulator_test.py
@@ -1,0 +1,96 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+from tachyon.result import ResultAccumulator
+from hammertime.http import Entry, StaticResponse
+
+
+class ResultAccumulatorTest(TestCase):
+
+    def test_add_entry(self):
+        entry = Entry.create(url="http://example.com/passwd",
+                             arguments={
+                               "file": {
+                                   "description": "password",
+                                   "severity": "critical",
+                               }
+                             },
+                             response=StaticResponse(200, content="hello", headers={}))
+
+        manager = MagicMock()
+
+        acc = ResultAccumulator(output_manager=manager)
+        acc.add_entry(entry)
+
+        manager.output_result.assert_called_with("password at: http://example.com/passwd", data={
+            "url": "http://example.com/passwd",
+            "description": "password",
+            "code": 200,
+            "severity": "critical",
+        })
+
+    def test_add_empty_entry(self):
+        entry = Entry.create(url="http://example.com/passwd",
+                             arguments={
+                               "file": {
+                                   "description": "password",
+                                   "severity": "critical",
+                               }
+                             },
+                             response=StaticResponse(200, content="", headers={}))
+
+        manager = MagicMock()
+
+        acc = ResultAccumulator(output_manager=manager)
+        acc.add_entry(entry)
+
+        manager.output_result.assert_called_with("Empty password at: http://example.com/passwd", data={
+            "url": "http://example.com/passwd",
+            "description": "password",
+            "code": 200,
+            "severity": "critical",
+        })
+
+    def test_path_entry(self):
+        entry = Entry.create(url="http://example.com/private/",
+                             arguments={
+                               "path": {
+                                   "description": "private",
+                                   "severity": "medium",
+                               }
+                             },
+                             response=StaticResponse(401, content="", headers={}))
+
+        manager = MagicMock()
+
+        acc = ResultAccumulator(output_manager=manager)
+        acc.add_entry(entry)
+
+        manager.output_result.assert_called_with("Password Protected - private at: http://example.com/private/", data={
+            "url": "http://example.com/private/",
+            "description": "private",
+            "code": 401,
+            "severity": "medium",
+        })
+
+    def test_tomcat_redirect_detected(self):
+        entry = Entry.create(url="http://example.com/private/",
+                             arguments={
+                               "path": {
+                                   "description": "private",
+                                   "severity": "medium",
+                               }
+                             },
+                             response=StaticResponse(404, content="Apache Tomcat/", headers={}))
+
+        manager = MagicMock()
+
+        acc = ResultAccumulator(output_manager=manager)
+        acc.add_entry(entry)
+
+        manager.output_result.assert_called_with("Tomcat redirect, private at: http://example.com/private/", data={
+            "url": "http://example.com/private/",
+            "description": "private",
+            "code": 404,
+            "severity": "medium",
+            "special": "tomcat-redirect",
+        })

--- a/test/result_accumulator_test.py
+++ b/test/result_accumulator_test.py
@@ -29,6 +29,17 @@ class ResultAccumulatorTest(TestCase):
             "severity": "critical",
         })
 
+    def test_add_without_arguments(self):
+        entry = Entry.create(url="http://example.com/passwd",
+                             response=StaticResponse(200, content="hello", headers={}))
+
+        manager = MagicMock()
+
+        acc = ResultAccumulator(output_manager=manager)
+        acc.add_entry(entry)
+
+        manager.output_result.assert_not_called()
+
     def test_add_empty_entry(self):
         entry = Entry.create(url="http://example.com/passwd",
                              arguments={

--- a/test/tachyon_test.py
+++ b/test/tachyon_test.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch, call, ANY
 
 from aiohttp.test_utils import make_mocked_coro
-from fixtures import async, patch_coroutines
+from fixtures import async, patch_coroutines, FakeHammerTimeEngine
 from hammertime.core import HammerTime
 
 from tachyon import __main__ as tachyon, database
@@ -124,8 +124,10 @@ class TestTachyon(TestCase):
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
     @async()
-    async def test_fetch_session_cookies_on_scan_start_if_no_user_supplied_cookies(self):
-        hammertime = MagicMock()
+    async def test_fetch_session_cookies_on_scan_start_if_no_user_supplied_cookies(self, loop):
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
 
         await tachyon.scan(hammertime, cookies=None, accumulator=self.accumulator)
 
@@ -133,8 +135,10 @@ class TestTachyon(TestCase):
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
     @async()
-    async def test_dont_fetch_session_cookies_on_scan_start_if_user_supplied_cookies(self):
-        hammertime = MagicMock()
+    async def test_dont_fetch_session_cookies_on_scan_start_if_user_supplied_cookies(self, loop):
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
         cookies = "not none"
 
         await tachyon.scan(hammertime, cookies=cookies, accumulator=self.accumulator)
@@ -142,10 +146,12 @@ class TestTachyon(TestCase):
         tachyon.get_session_cookies.assert_not_called()
 
     @async()
-    async def test_use_user_supplied_cookies_if_available(self):
+    async def test_use_user_supplied_cookies_if_available(self, loop):
         database.session_cookie = "my-cookies=123"
         cookies = "test-cookie=true"
-        hammertime = MagicMock()
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
 
         with patch("tachyon.config.add_http_header") as add_http_header:
             await tachyon.scan(hammertime, cookies=cookies, accumulator=self.accumulator)
@@ -154,8 +160,10 @@ class TestTachyon(TestCase):
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
     @async()
-    async def test_scan_directory_only(self):
-        hammertime = MagicMock()
+    async def test_scan_directory_only(self, loop):
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
 
         await tachyon.scan(hammertime, directories_only=True, accumulator=self.accumulator)
 
@@ -164,18 +172,22 @@ class TestTachyon(TestCase):
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
     @async()
-    async def test_scan_file_only(self):
-        hammertime = MagicMock()
+    async def test_scan_file_only(self, loop):
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
 
         await tachyon.scan(hammertime, files_only=True, accumulator=self.accumulator)
 
-        tachyon.test_file_exists.assert_called_once_with(hammertime, accumulator=self.accumulator)
+        tachyon.test_file_exists.assert_called_with(hammertime, accumulator=self.accumulator)
         tachyon.test_paths_exists.assert_not_called()
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
     @async()
-    async def test_scan_plugins_only(self):
-        hammertime = MagicMock()
+    async def test_scan_plugins_only(self, loop):
+        engine = FakeHammerTimeEngine()
+        hammertime = HammerTime(request_engine=engine, loop=loop)
+        hammertime.collect_successful_requests()
 
         await tachyon.scan(hammertime, plugins_only=True, accumulator=self.accumulator)
 

--- a/test/tachyon_test.py
+++ b/test/tachyon_test.py
@@ -26,6 +26,8 @@ from fixtures import async, patch_coroutines
 from hammertime.core import HammerTime
 
 from tachyon import __main__ as tachyon, database
+from tachyon.result import ResultAccumulator
+from tachyon.output import PrettyOutput
 
 
 class TestTachyon(TestCase):
@@ -33,6 +35,7 @@ class TestTachyon(TestCase):
     def setUp(self):
         tachyon.load_execute_file_plugins = MagicMock()
         tachyon.load_execute_host_plugins = make_mocked_coro()
+        self.accumulator = ResultAccumulator(output_manager=PrettyOutput)
 
     @classmethod
     def setUpClass(cls):
@@ -52,7 +55,7 @@ class TestTachyon(TestCase):
         tachyon.PathGenerator = MagicMock(return_value=path_generator)
         tachyon.DirectoryFetcher = MagicMock(return_value=fake_directory_fetcher)
 
-        await tachyon.test_paths_exists(HammerTime(loop=loop))
+        await tachyon.test_paths_exists(HammerTime(loop=loop), accumulator=self.accumulator)
 
         fake_directory_fetcher.fetch_paths.assert_called_once_with(path_generator.generate_paths.return_value)
 
@@ -67,7 +70,7 @@ class TestTachyon(TestCase):
         tachyon.DirectoryFetcher = MagicMock(return_value=fake_directory_fetcher)
 
         with patch("tachyon.textutils.output_info") as output_info:
-            await tachyon.test_paths_exists(HammerTime(loop=loop))
+            await tachyon.test_paths_exists(HammerTime(loop=loop), accumulator=self.accumulator)
 
             output_info.assert_any_call("Probing %d paths" % len(paths))
 
@@ -81,7 +84,7 @@ class TestTachyon(TestCase):
         tachyon.PathGenerator = MagicMock(return_value=path_generator)
         tachyon.DirectoryFetcher = MagicMock(return_value=fake_directory_fetcher)
 
-        await tachyon.test_paths_exists(HammerTime(loop=loop), recursive=True)
+        await tachyon.test_paths_exists(HammerTime(loop=loop), recursive=True, accumulator=self.accumulator)
 
         path_generator.generate_paths.assert_has_calls([call(use_valid_paths=False), call(use_valid_paths=True),
                                                         call(use_valid_paths=True)], any_order=False)
@@ -101,7 +104,7 @@ class TestTachyon(TestCase):
         database.valid_paths = paths
 
         with patch("tachyon.textutils.output_info") as output_info:
-            await tachyon.test_paths_exists(HammerTime(loop=loop))
+            await tachyon.test_paths_exists(HammerTime(loop=loop), accumulator=self.accumulator)
 
             output_info.assert_any_call("Found %d valid paths" % len(database.valid_paths))
 
@@ -115,7 +118,7 @@ class TestTachyon(TestCase):
         fake_file_generator.generate_files.return_value = ["list of files"]
 
         with patch("tachyon.__main__.FileGenerator", MagicMock(return_value=fake_file_generator)):
-            await tachyon.test_file_exists(HammerTime(loop=loop))
+            await tachyon.test_file_exists(HammerTime(loop=loop), accumulator=self.accumulator)
 
         fake_file_fetcher.fetch_files.assert_called_once_with(["list of files"])
 
@@ -124,7 +127,7 @@ class TestTachyon(TestCase):
     async def test_fetch_session_cookies_on_scan_start_if_no_user_supplied_cookies(self):
         hammertime = MagicMock()
 
-        await tachyon.scan(hammertime, cookies=None)
+        await tachyon.scan(hammertime, cookies=None, accumulator=self.accumulator)
 
         tachyon.get_session_cookies.assert_called_once_with(hammertime)
 
@@ -134,7 +137,7 @@ class TestTachyon(TestCase):
         hammertime = MagicMock()
         cookies = "not none"
 
-        await tachyon.scan(hammertime, cookies=cookies)
+        await tachyon.scan(hammertime, cookies=cookies, accumulator=self.accumulator)
 
         tachyon.get_session_cookies.assert_not_called()
 
@@ -145,7 +148,7 @@ class TestTachyon(TestCase):
         hammertime = MagicMock()
 
         with patch("tachyon.config.add_http_header") as add_http_header:
-            await tachyon.scan(hammertime, cookies=cookies)
+            await tachyon.scan(hammertime, cookies=cookies, accumulator=self.accumulator)
 
             add_http_header.assert_any_call(ANY, "Cookie", "test-cookie=true")
 
@@ -154,9 +157,9 @@ class TestTachyon(TestCase):
     async def test_scan_directory_only(self):
         hammertime = MagicMock()
 
-        await tachyon.scan(hammertime, directories_only=True)
+        await tachyon.scan(hammertime, directories_only=True, accumulator=self.accumulator)
 
-        tachyon.test_paths_exists.assert_called_once_with(hammertime)
+        tachyon.test_paths_exists.assert_called_once_with(hammertime, accumulator=self.accumulator)
         tachyon.test_file_exists.assert_not_called()
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
@@ -164,9 +167,9 @@ class TestTachyon(TestCase):
     async def test_scan_file_only(self):
         hammertime = MagicMock()
 
-        await tachyon.scan(hammertime, files_only=True)
+        await tachyon.scan(hammertime, files_only=True, accumulator=self.accumulator)
 
-        tachyon.test_file_exists.assert_called_once_with(hammertime)
+        tachyon.test_file_exists.assert_called_once_with(hammertime, accumulator=self.accumulator)
         tachyon.test_paths_exists.assert_not_called()
 
     @patch_coroutines("tachyon.__main__.", "test_file_exists", "test_paths_exists", "get_session_cookies")
@@ -174,7 +177,7 @@ class TestTachyon(TestCase):
     async def test_scan_plugins_only(self):
         hammertime = MagicMock()
 
-        await tachyon.scan(hammertime, plugins_only=True)
+        await tachyon.scan(hammertime, plugins_only=True, accumulator=self.accumulator)
 
         tachyon.load_execute_host_plugins.assert_called_once_with(hammertime)
         tachyon.test_file_exists.assert_not_called()


### PR DESCRIPTION
* Make sure all of the results go through the same accumulator object
* Always display the findings interactively in pretty-print mode
* Revalidate the results at the end of the scan
  * First by making sure the responses did not make their way into the error behavior naughty list.
  * Second by re-querying the remaining files
  * Re-validation is done serially to avoid load-related behavior as much as possible.
* Log the behavior change only once when it first occurs, indicating that re-validation will happen.

Note: **Build fails because of a dependency on HammerTime to be merged/released first**